### PR TITLE
Fix Warning: Each child in a list should have a unique "key" prop.

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -17,7 +17,7 @@ export function Footer() {
       <div className="sponsors">
         <div className="sponsors__label">Yhteistyössä</div>
         {sponsors.map(sponsor => (
-          <SponsorLink key={sponsor.id} {...sponsor} />
+          <SponsorLink key={sponsor.name} {...sponsor} />
         ))}
       </div>
       <div className="contacts">


### PR DESCRIPTION
Sponsors don't have ids – name is probably unique and can be used as a key