### PR TITLE
Improve performance

### DIFF
--- a/components/Feed.jsx
+++ b/components/Feed.jsx
@@ -33,7 +33,7 @@ export default class Feed extends React.Component {
 
   render() {
     const messages = this.state.messages.map((message, i) => {
-      let image = <img src={message.image} alt="" />;
+      let image = <img src={message.image} alt="" loading="lazy" />;
 
       if (message.imageLink) {
         image = (

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -7,6 +7,7 @@ const SponsorLink = ({ href, name }) => (
       src={`/static/images/sponsors/${name.toLowerCase()}.svg`}
       alt={name}
       className={`sponsor sponsor__${name.toLowerCase()}`}
+      loading="lazy"
     />
   </a>
 );

--- a/components/Members.jsx
+++ b/components/Members.jsx
@@ -23,7 +23,15 @@ export default class Members extends React.Component {
     const members = this.state.members.map(member => {
       const src = `${member.avatar_url}&s=120`;
       return (
-        <img className="member" key={member.avatar_url} src={src} alt="" />
+        <img
+          className="member"
+          key={member.avatar_url}
+          src={src}
+          alt=""
+          width={30}
+          height={30}
+          loading="lazy"
+        />
       );
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9019,11 +9019,6 @@
         "scroll-into-view-if-needed": "^2.2.16"
       }
     },
-    "react-stripe-checkout": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/react-stripe-checkout/-/react-stripe-checkout-2.6.3.tgz",
-      "integrity": "sha1-MXOocLBOWjwyGgbSTNU8YDARHEU="
-    },
     "react-time-ago": {
       "version": "5.0.7",
       "resolved": "https://registry.npmjs.org/react-time-ago/-/react-time-ago-5.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "react": "^16.11.0",
     "react-dom": "^16.11.0",
     "react-ga": "^2.7.0",
-    "react-stripe-checkout": "^2.6.3",
     "react-time-ago": "^5.0.7",
     "stylus": "^0.54.7",
     "twitter-text": "^3.0.0"

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -60,7 +60,6 @@ class MyDocument extends Document {
           />
           <link rel="manifest" href="/static/icons/site.webmanifest" />
           <meta property="og:image" content="images/logo.png" />
-          <script src="https://js.stripe.com/v3/" />
           <script src="//use.typekit.net/scb5xny.js" />
           <script>{"try{Typekit.load();}catch(e){};"}</script>
         </Head>

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -60,8 +60,6 @@ class MyDocument extends Document {
           />
           <link rel="manifest" href="/static/icons/site.webmanifest" />
           <meta property="og:image" content="images/logo.png" />
-          <script src="//use.typekit.net/scb5xny.js" />
-          <script>{"try{Typekit.load();}catch(e){};"}</script>
         </Head>
         <body>
           <div className="site">

--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -65,11 +65,11 @@ class MyDocument extends Document {
           <div className="site">
             <div className="container">
               <Main />
-              <NextScript />
             </div>
             <Footer />
           </div>
           <Fader />
+          <NextScript />
         </body>
       </Html>
     );

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -38,7 +38,7 @@ const PatientProject = ({ title, description, url, image }) => (
   <div className="bread">
     <div className="column column2-5">
       <a href={url} target="_blank" rel="noopener noreferrer">
-        <img src={image} style={{ width: "7rem" }} alt={title} />
+        <img src={image} style={{ width: "7rem" }} alt={title} loading="lazy" />
       </a>
     </div>
     <div className="column column3-5">
@@ -103,6 +103,7 @@ const IndexContent = () => (
                 <img
                   src="/static/images/slack.png"
                   alt="Slack app at Koodiklinikka"
+                  loading="lazy"
                 />
               </a>
             </div>
@@ -114,6 +115,7 @@ const IndexContent = () => (
               <img
                 src="/static/images/octocat.png"
                 alt="Octocat, the mascot of GitHub"
+                loading="lazy"
               />
             </div>
             <div className="column column3-5">

--- a/styles/style.styl
+++ b/styles/style.styl
@@ -185,14 +185,6 @@ section:first-child
   height 70px
   margin auto
 
-.stripe-form
-  margin 20px 0px
-  .name
-    margin-top 20px
-    text-align left
-    display block
-    color rgba(0, 0, 0, 0.4)
-
 @keyframes drop
   0%
     transform rotateX(90deg)


### PR DESCRIPTION
- Remove render blocking JS
- Use `loading="lazy"` for images
- Prioritize content rendering over hydration

I understand if changing the how the texts look like due to performance reasons is not an acceptable change and https://github.com/koodiklinikka/koodiklinikka.fi/commit/e8960ec11379ee929307fc978e47b023ba68ec2b can be easily reverted if needed.

![Screenshot_2019-11-02_21-42-29](https://user-images.githubusercontent.com/6113341/68076149-b2ad7500-fdb9-11e9-9683-aafada8128c0.png)

