### PR TITLE
Decrease .feed width at a certain screen size

### DIFF
--- a/styles/style.styl
+++ b/styles/style.styl
@@ -284,6 +284,12 @@ footer
   &::-webkit-scrollbar
       display none
 
+@media screen and (max-width: 1200px)
+  .feed
+    width 350px
+  .content.with-feed
+    padding-right 350px
+
 @media screen and (max-width: 980px)
   .feed
     width 0


### PR DESCRIPTION
I saw that when you got to a certain screen size, the image became too small and the text became too condensed.

Before:
![feed](https://user-images.githubusercontent.com/39559256/94021589-d9eba700-fdbc-11ea-9101-b61f5cf1bc88.PNG)

After:
![feed2](https://user-images.githubusercontent.com/39559256/94021695-fc7dc000-fdbc-11ea-91cb-16b658a79d31.PNG)
