### PR TITLE
 Inline the CSS for improved first paint performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "start": "next",
     "build": "next build && next export",
-    "dev": "SERVER=http://localhost:9000/ ENV=development next",
-    "prod": "ENV=production next build && next export",
+    "dev": "SERVER=http://localhost:9000/ NODE_ENV=development next",
+    "prod": "NODE_ENV=production next build && next export",
     "lint": "eslint --ext .jsx --ext .js .",
     "prettify": "prettier --write components pages styles"
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "font-awesome": "^4.7.0",
     "less": "^3.10.3",
     "lodash": "^4.17.15",
-    "next": "^9.1.2",
+    "next": "^9.5.3",
     "next-fonts": "^1.4.0",
     "parse-github-event": "^1.1.3",
     "react": "^16.11.0",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,6 +3,26 @@ import Document, { Html, Head, Main, NextScript } from "next/document";
 import { Footer } from "../components/Footer";
 import Fader from "../components/Fader";
 import ReactGA from "react-ga";
+import fs from "fs";
+import path from "path";
+
+class CustomNextHead extends Head {
+  // TODO: This might not be needed if Next.js implements built-in support
+  // https://github.com/zeit/next-plugins/issues/364
+  getCssLinks({ allFiles }) {
+    return allFiles
+      .filter(file => file.endsWith(".css"))
+      .map(file => (
+        <style
+          key={file}
+          nonce={this.props.nonce}
+          dangerouslySetInnerHTML={{
+            __html: fs.readFileSync(path.join(".next", file), "utf-8"),
+          }}
+        />
+      ));
+  }
+}
 
 function trackPageView() {
   if (location.hostname === "localhost" || location.hostname === "127.0.0.1") {
@@ -29,7 +49,7 @@ class MyDocument extends Document {
   render() {
     return (
       <Html lang="fi">
-        <Head />
+        <CustomNextHead />
         <body>
           <div className="site">
             <div className="container">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4144,7 +4144,7 @@ next-tick@~1.0.0:
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
-next@^9.1.2:
+next@^9.5.3:
   version "9.5.3"
   resolved "https://registry.yarnpkg.com/next/-/next-9.5.3.tgz#7af5270631f98d330a7f75a6e8e1ac202aa155e2"
   integrity sha512-DGrpTNGV2RNMwLaSzpgbkbaUuVk30X71/roXHS10isSXo2Gm+qWcjonDyOxf1KmOvHZRHA/Fa+LaAR7ysdYS3A==


### PR DESCRIPTION
Needed to upgrade the Next.js version in order to use the new `getCssLinks` that gets `allFiles` passed to it.

Workaround for missing built-in support for inlining CSS copied from here: https://github.com/vercel/next-plugins/issues/238#issuecomment-696623272

Before:
![image](https://user-images.githubusercontent.com/6113341/94324648-5dff8380-ffa3-11ea-8ad0-e47e5d7f6d19.png)

https://webpagetest.org/result/200925_64_4defcc6836fa2ca04c1c5b6fda6567c6/

After:
![image](https://user-images.githubusercontent.com/6113341/94324607-4e803a80-ffa3-11ea-9c75-7a3f9628d53e.png)

https://webpagetest.org/result/200925_PH_aebda69748a23f2e3b384408623c94ae/