### PR TITLE
Hide frontpage channel descriptions

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -130,18 +130,10 @@ const IndexContent = (props: IndexProps) => (
                             #{channel.name}
                           </a>
                         </div>
-                        <span className="channel-members">
-                          {channel.num_members} jäsentä
-                        </span>
                       </td>
                       <td>
-                        <span>
-                          <ReactMarkdown
-                            className="channel-topic"
-                            components={{ p: ChannelReferenceRenderer }}
-                          >
-                            {channel.topic}
-                          </ReactMarkdown>
+                        <span className="channel-members">
+                          {channel.num_members} jäsentä
                         </span>
                       </td>
                     </tr>

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -389,8 +389,8 @@ footer {
 }
 .social {
   height: 30px;
-  margin-left: .5em;
-  margin-right: .5em;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
 }
 .feed {
   width: $feedWidth;

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -533,7 +533,6 @@ footer {
   }
 }
 .channels {
-  width: 100%;
   list-style: none;
   padding: 0;
   td {
@@ -583,6 +582,7 @@ footer {
 }
 .channel-members {
   font-size: 12px;
+  margin-left: 1rem;
 }
 .channel-topic {
   p {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": false,
@@ -19,17 +15,7 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "typeRoots": [
-    "./node_modules/@types",
-    "./typings"
-  ],
-  "exclude": [
-    "node_modules"
-  ],
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    "./typings/*"
-  ]
+  "typeRoots": ["./node_modules/@types", "./typings"],
+  "exclude": ["node_modules"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "./typings/*"]
 }


### PR DESCRIPTION
## Meta

First commit about Prettier changes only (`yarn prettify`), second commit about actual changes.

## What?

Hiding the frontpage channel descriptions from the site, as those contained some pretty stale and frankly outdated (considering the CoC) content as of 28.2.2023, see screenshot:

![Screenshot 2023-02-28 at 14 06 15](https://user-images.githubusercontent.com/16202979/221867563-bd540cb5-d5fa-4948-91dd-150c721fbdf0.png)

So what this PR does is hide the channel descriptions as a quick fix, which in practice looks like this:

![Screenshot 2023-02-28 at 15 29 14](https://user-images.githubusercontent.com/16202979/221868347-877b790e-49f1-4924-922b-e4efff0e106b.png)

![Screenshot 2023-02-28 at 15 29 43](https://user-images.githubusercontent.com/16202979/221868350-5ad75ff5-5c9d-4652-9ecf-92c4c4e0dc1e.png)

Note that I don't consider myself a designer or a UI authority by any means, so further design iterations are welcome 😄 

**Original Slack discussion: https://koodiklinikka.slack.com/archives/C6P893LFK/p1677587646981509**

## Todo

As discussed in the thread, it seems to me that the channel data fetch is done during build time and thus stale at runtime, even thought there's a supposed mechanism for refetching. That's not addressed here, as this PR is about a quick UI level fix only.